### PR TITLE
楽天商品検索APIと楽天商品ランキングAPIをHTTPSに対応

### DIFF
--- a/lib/RakutenRws/Api/Definition/IchibaItemRanking.php
+++ b/lib/RakutenRws/Api/Definition/IchibaItemRanking.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_IchibaItemRanking extends RakutenRws_Api_AppRaku
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-06-28' => '20170628',
             '2012-09-27' => '20120927'
         );
 

--- a/lib/RakutenRws/Api/Definition/IchibaItemSearch.php
+++ b/lib/RakutenRws/Api/Definition/IchibaItemSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_IchibaItemSearch extends RakutenRws_Api_AppRakut
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-07-06' => '20170706',
             '2014-02-22' => '20140222',
             '2013-08-05' => '20130805',
             '2013-04-24' => '20130424',


### PR DESCRIPTION
楽天商品検索APIと楽天商品ランキングAPIを、HTTPSのURLに対応した新しいバージョンのものに差し替えました。
APIのバージョンは、executeの第3引数で指定できますが、versionMap配列にないとエラーになります。

この修正により、デフォルトで最新のAPIのバージョンを指し示すようになります。
楽天商品検索APIはレスポンスデータ中のURLがHTTPSになります。
楽天商品ランキングAPIは古いドキュメントを参照できませんでしたが、サンプルのコードを実行したところ、同様の挙動を示しました。

**参照**
https://webservice.rakuten.co.jp/api/ichibaitemsearch/
https://webservice.rakuten.co.jp/api/ichibaitemranking/