### PR TITLE
[review] APIバージョンアップデート

### DIFF
--- a/lib/RakutenRws/Api/Definition/BooksBookSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksBookSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksBookSearch extends RakutenRws_Api_AppRakute
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksCDSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksCDSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksCDSearch extends RakutenRws_Api_AppRakutenA
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksDVDSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksDVDSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksDVDSearch extends RakutenRws_Api_AppRakuten
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksForeignBookSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksForeignBookSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksForeignBookSearch extends RakutenRws_Api_Ap
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksMagazineSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksMagazineSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksMagazineSearch extends RakutenRws_Api_AppRa
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksSoftwareSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksSoftwareSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksSoftwareSearch extends RakutenRws_Api_AppRa
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/BooksTotalSearch.php
+++ b/lib/RakutenRws/Api/Definition/BooksTotalSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_BooksTotalSearch extends RakutenRws_Api_AppRakut
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-04' => '20170404',
             '2013-05-22' => '20130522',
             '2012-11-28' => '20121128'
         );

--- a/lib/RakutenRws/Api/Definition/IchibaItemRanking.php
+++ b/lib/RakutenRws/Api/Definition/IchibaItemRanking.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_IchibaItemRanking extends RakutenRws_Api_AppRaku
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-06-28' => '20170628',
             '2012-09-27' => '20120927'
         );
 

--- a/lib/RakutenRws/Api/Definition/IchibaItemSearch.php
+++ b/lib/RakutenRws/Api/Definition/IchibaItemSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_IchibaItemSearch extends RakutenRws_Api_AppRakut
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-07-06' => '20170706',
             '2014-02-22' => '20140222',
             '2013-08-05' => '20130805',
             '2013-04-24' => '20130424',

--- a/lib/RakutenRws/Api/Definition/KoboEbookSearch.php
+++ b/lib/RakutenRws/Api/Definition/KoboEbookSearch.php
@@ -21,6 +21,7 @@ class RakutenRws_Api_Definition_KoboEbookSearch extends RakutenRws_Api_AppRakute
         $autoSetIterator = true,
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2014-08-11' => '20140811',
             '2013-10-10' => '20131010'
         );

--- a/lib/RakutenRws/Api/Definition/ProductSearch.php
+++ b/lib/RakutenRws/Api/Definition/ProductSearch.php
@@ -23,6 +23,7 @@ class RakutenRws_Api_Definition_ProductSearch extends RakutenRws_Api_AppRakutenA
         $entityName = 'Product',
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2014-03-05' => '20140305',
         );
 

--- a/lib/RakutenRws/Api/Definition/RecipeCategoryList.php
+++ b/lib/RakutenRws/Api/Definition/RecipeCategoryList.php
@@ -20,6 +20,7 @@ class RakutenRws_Api_Definition_RecipeCategoryList extends RakutenRws_Api_AppRak
     protected
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2012-11-21' => '20121121'
         );
 

--- a/lib/RakutenRws/Api/Definition/RecipeCategoryRanking.php
+++ b/lib/RakutenRws/Api/Definition/RecipeCategoryRanking.php
@@ -20,6 +20,7 @@ class RakutenRws_Api_Definition_RecipeCategoryRanking extends RakutenRws_Api_App
     protected
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2012-11-21' => '20121121'
         );
 

--- a/lib/RakutenRws/Api/Definition/TravelHotelDetailSearch.php
+++ b/lib/RakutenRws/Api/Definition/TravelHotelDetailSearch.php
@@ -23,6 +23,7 @@ class RakutenRws_Api_Definition_TravelHotelDetailSearch extends RakutenRws_Api_A
         $entityName = 'hotel',
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2013-10-24' => '20131024',
         );
 

--- a/lib/RakutenRws/Api/Definition/TravelHotelRanking.php
+++ b/lib/RakutenRws/Api/Definition/TravelHotelRanking.php
@@ -20,6 +20,7 @@ class RakutenRws_Api_Definition_TravelHotelRanking extends RakutenRws_Api_AppRak
     protected
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2013-10-24' => '20131024',
         );
 

--- a/lib/RakutenRws/Api/Definition/TravelKeywordHotelSearch.php
+++ b/lib/RakutenRws/Api/Definition/TravelKeywordHotelSearch.php
@@ -23,6 +23,7 @@ class RakutenRws_Api_Definition_TravelKeywordHotelSearch extends RakutenRws_Api_
         $entityName = 'hotel',
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2013-10-24' => '20131024',
         );
 

--- a/lib/RakutenRws/Api/Definition/TravelSimpleHotelSearch.php
+++ b/lib/RakutenRws/Api/Definition/TravelSimpleHotelSearch.php
@@ -23,6 +23,7 @@ class RakutenRws_Api_Definition_TravelSimpleHotelSearch extends RakutenRws_Api_A
         $entityName = 'hotel',
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2013-10-24' => '20131024',
         );
 

--- a/lib/RakutenRws/Api/Definition/TravelVacantHotelSearch.php
+++ b/lib/RakutenRws/Api/Definition/TravelVacantHotelSearch.php
@@ -23,6 +23,7 @@ class RakutenRws_Api_Definition_TravelVacantHotelSearch extends RakutenRws_Api_A
         $entityName = 'hotel',
         $isRequiredAccessToken = false,
         $versionMap = array(
+            '2017-04-26' => '20170426',
             '2013-10-24' => '20131024',
         );
 


### PR DESCRIPTION
ランキング検索APIから取得したレスポンスに無効な`itemCode`が返却されていました。
（ここで取得できる`itemCode`を商品検索APIに渡しても`contents`が返ってこないという意味で無効）
調べてみるとAPIのバージョンが古いことで発生しているようでした。（`IchibaItemRanking 2012-09-27版`）

手元の環境では、ランキング検索と商品検索のAPIをバージョンアップして動作確認したのですが、本レポジトリにマージしていただければcomposerから利用されているユーザーにもメリットがあるのでは？とおもいPRしました。

※最新のバージョンは、[楽天ウェブサービス: API一覧](https://webservice.rakuten.co.jp/document/)を参考にしました。このサイトに記載されているAPIのバージョンを追加しています。

レビュー＆マージいただけると幸いです。